### PR TITLE
Fix exposings and improve summary

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -1,13 +1,14 @@
 {
     "type": "package",
     "name": "choonkeat/elm-totp",
-    "summary": "Library for Elm to generate TOTP url keys and code",
+    "summary": "Create TOTP urls and code. Useful for 2FA and authenticators.",
     "license": "BSD-3-Clause",
     "version": "1.1.1",
     "exposed-modules": [
         "TOTP",
         "TOTP.Algorithm",
-        "TOTP.Key"
+        "TOTP.Key",
+        "TOTP.Base32String"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {


### PR DESCRIPTION
This package is not possible to use for creating codes due to `TOTP.generateTOTP` requiring a Base32String which is in an unexposed module.

I also improved the package summary. I wasn't able to find this on the package website because I was using the search terms "2FA" and "authenticator".